### PR TITLE
Actually return urls in _get_urls

### DIFF
--- a/djangojs/urls_serializer.py
+++ b/djangojs/urls_serializer.py
@@ -43,7 +43,7 @@ def urls_as_dict():
     urls = {}
     if settings.JS_URLS_ENABLED:
         if isinstance(module, (six.text_type, six.string_types)):
-            _get_urls(module)
+            urls = _get_urls(module)
         else:
             for item in module:
                 urls = dict(urls.items() + _get_urls(item).items())


### PR DESCRIPTION
Otherwise if this condition is met, `window.DJANGO_JS_URLS` is always empty.
